### PR TITLE
stat error when checksumming a file that does not exist

### DIFF
--- a/checksum.js
+++ b/checksum.js
@@ -57,9 +57,9 @@ function checksumFile (filename, options, callback) {
   if (!options.algorithm) options.algorithm = 'sha1'
 
   fs.stat(filename, function (err, stat) {
-    if (!stat.isFile()) err = new Error('Not a file')
     if (err) return callback(err)
-
+    if (!stat.isFile()) err = new Error('Not a file')
+    
     var hash = crypto.createHash(options.algorithm)
       , fileStream = fs.createReadStream(filename)
 

--- a/test/checksum.test.js
+++ b/test/checksum.test.js
@@ -18,5 +18,8 @@ test('checksum.file', function (t) {
   checksum.file('./fixtures/1px.gif', function (err, sum) {
     t.equal(sum, 'c65ed837d46f9122ab047c33d2f9e947786187b4', 'binary file checksum')
   })
+  checksum.file('./idontexist.text', function (err, sum){
+    t.equal(err.errno, 34, 'the stat error will be passed along')
+  })
 })
 


### PR DESCRIPTION
I noticed that when I attempt to checksum a file that does not exist, an inappropriate error was being thrown. I added a test and a fix for it.

Basically, the stat result was being used before checking if there was an error from the stat call.
