### PR TITLE
Add encoding support to checksum

### DIFF
--- a/checksum.js
+++ b/checksum.js
@@ -26,6 +26,7 @@ checksum.file = checksumFile
 function checksum (value, options) {
   options || (options = {})
   if (!options.algorithm) options.algorithm = 'sha1'
+  if (!options.encoding) options.encoding = 'hex'
 
   var hash = crypto.createHash(options.algorithm)
 
@@ -33,13 +34,13 @@ function checksum (value, options) {
   if (!hash.write) { 
     // pre-streaming crypto API in node < v0.9
     hash.update(value)
-    return hash.digest('hex')
+    return hash.digest(options.encoding)
 
   } else {
     // v0.9+ streaming crypto
     // http://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback
     hash.write(value)
-    return hash.digest('hex')
+    return hash.digest(options.encoding)
 
   }
 }
@@ -56,6 +57,7 @@ function checksumFile (filename, options, callback) {
 
   options || (options = {})
   if (!options.algorithm) options.algorithm = 'sha1'
+  if (!options.encoding) options.encoding = 'hex'
 
   fs.stat(filename, function (err, stat) {
     if (!err && !stat.isFile()) err = new Error('Not a file')
@@ -72,12 +74,12 @@ function checksumFile (filename, options, callback) {
       })
 
       fileStream.on('end', function () {
-        callback(null, hash.digest('hex'))
+        callback(null, hash.digest(options.encoding))
       })
 
     } else { // v0.9+ streaming crypto
 
-      hash.setEncoding('hex')
+      hash.setEncoding(options.encoding)
       fileStream.pipe(hash, { end: false })
 
       fileStream.on('end', function () {

--- a/test/checksum.test.js
+++ b/test/checksum.test.js
@@ -23,3 +23,22 @@ test('checksum.file', function (t) {
   })
 })
 
+// Passing encoding
+test('checksum.base64', function (t) {
+  t.equal(checksum('dshaw', { encoding: 'base64' }), 'm4zrwEISQdCH9qt+gVKFr4A95+c=', 'simple value')
+  t.equal(checksum('1234567890~!@#$%^&*()_+', { encoding: 'base64' }), '1VMD0KGUMslonJ6/Uc7lH0U7k70=', 'more chars')
+  t.end()
+})
+
+test('checksum.file.base64', function (t) {
+  t.plan(3)
+  checksum.file('./fixtures/dshaw.txt', { encoding: 'base64' }, function (err, sum) {
+    t.equal(sum, 'm4zrwEISQdCH9qt+gVKFr4A95+c=', 'text file checksum')
+  })
+  checksum.file('./fixtures/1px.gif', { encoding: 'base64' }, function (err, sum) {
+    t.equal(sum, 'xl7YN9RvkSKrBHwz0vnpR3hhh7Q=', 'binary file checksum')
+  })
+  checksum.file('./idontexist.text', { encoding: 'base64' }, function (err, sum) {
+    t.equal(err.code, 'ENOENT', 'the stat error will be passed along')
+  })
+})


### PR DESCRIPTION
Parameter **encoding** can now be passed in  **options**

Base 64 encoded string is generated from hex-string using:
`new Buffer('string', 'hex').toString('base64')`